### PR TITLE
when `nextRelDoneId` is 0, `lastDoneReleaseDoneId` stays same

### DIFF
--- a/workers/proc.sign.eos.ext.wrk.js
+++ b/workers/proc.sign.eos.ext.wrk.js
@@ -165,7 +165,8 @@ class WrkEosSignMultisigProc extends WrkBase {
 
         // also skip nextRelDoneId 0 (not found)
         if (!nextRelDoneId) {
-          return { lastDoneReleaseDoneId: 0 }
+          const lrdid = res.stateRemote.lastDoneReleaseDoneId
+          return { lastDoneReleaseDoneId: lrdid }
         }
 
         await this.sendTx(remote, 'releasedone', { id: nextRelDoneId })
@@ -181,7 +182,8 @@ class WrkEosSignMultisigProc extends WrkBase {
         console.log(local, 'processPendingTransfers', JSON.stringify(res))
         console.log('processing', res.pendingLocal)
 
-        let { nextTransId, lastDoneReleaseDoneId } = res.stateRemote
+        let { nextTransId } = res.stateRemote
+        let { lastDoneReleaseDoneId } = res.pendingRelDone
 
         const pendingTransfers = res.pendingLocal
         async.eachSeries(pendingTransfers, async (entry) => {

--- a/workers/proc.sign.eos.ext.wrk.js
+++ b/workers/proc.sign.eos.ext.wrk.js
@@ -204,9 +204,7 @@ class WrkEosSignMultisigProc extends WrkBase {
 
               return
             }
-          }
-
-          if (id === nextTransId) {
+          } else if (id === nextTransId) {
             console.log('releasing id:', id)
             await this.sendTx(remote, 'release', { id, account, quantity, memo })
 


### PR DESCRIPTION
given the table for `pndtransfers` is empty, do not overwrite
`lastDoneReleaseDoneId`.