### PR TITLE
improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 Open source C++ to JS port.
 
+One worker will pull open transactions from the contract gateways via the HTTP API of the main and sidechain.
 
-A setup will need one `proc` worker (`proc.sign.eos.ext.wrk.js`).
-
-It will pull open transactions from the contract gateways via the HTTP API of the main and sidechain.
-
-It creates an *unsigned* transaction and sends it to the network, to the api workers (`api.sign.eos.ext.wrk.js`)
-for signing.
+It creates a signed transaction and sends it to the network for signing.
 
 Once the amount of required signatures is reached, the transaction is sent to the chain.
 
@@ -69,11 +65,8 @@ cleos set account permission testuser1511 active '{"threshold" : 100, "keys" : [
 ### Boot workers
 
 ```
-node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 8338 --chain=main
-node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 8337 --chain=main
-
-node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 7338 --chain=side
-node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 7337 --chain=side
+node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 8338
+node worker.js --env=development --wtype=wrk-ext-eos-sign-api  --apiPort 7338
 
 
 # to speed up developments and review, in development mode, passing of keys is possible via commandline:

--- a/test/unit.util.js
+++ b/test/unit.util.js
@@ -10,7 +10,8 @@ const {
   getKeysForSign,
   signTx,
   addSerializedTx,
-  getTimestamp
+  getTimestamp,
+  isTx
 } = require('../workers/util.js')
 
 const {
@@ -34,6 +35,131 @@ describe('unit util', () => {
     assert.throws(() => {
       getTimestamp(null)
     })
+  })
+
+  it('isTx - all valid', () => {
+    const tx = {
+      'expiration': '2050-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [],
+      'actions': [{ 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': []
+    }
+
+    const res = isTx(tx)
+    assert.strictEqual(res, true)
+  })
+
+  it('isTx - date invalid', () => {
+    const tx = {
+      'expiration': '2000-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [],
+      'actions': [{ 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': []
+    }
+
+    const res = isTx(tx)
+    assert.strictEqual(res, false)
+  })
+
+  it('isTx - actions invalid', () => {
+    const tx = {
+      'expiration': '2000-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [],
+      'actions': [1, { 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': []
+    }
+
+    assert.throws(() => {
+      isTx(tx)
+    }, new Error('ERR_FATAL_INVALID_TX'))
+  })
+
+  it('isTx - context_free_actions invalid', () => {
+    const tx = {
+      'expiration': '2000-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [1],
+      'actions': [{ 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': []
+    }
+
+    assert.throws(() => {
+      isTx(tx)
+    }, new Error('ERR_FATAL_INVALID_TX'))
+  })
+
+  it('isTx - context_free_data invalid', () => {
+    const tx = {
+      'expiration': '2000-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [],
+      'context_free_data': [],
+      'actions': [{ 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': []
+    }
+
+    assert.throws(() => {
+      isTx(tx)
+    }, new Error('ERR_FATAL_INVALID_TX'))
+  })
+
+  it('isTx - transaction_extensions invalid', () => {
+    const tx = {
+      'expiration': '2000-07-26T13:48:29.000',
+      'ref_block_num': 29595,
+      'ref_block_prefix': 3916965506,
+      'max_net_usage_words': 0,
+      'max_cpu_usage_ms': 0,
+      'delay_sec': 0,
+      'context_free_actions': [],
+      'actions': [{ 'account': 'finexsidegtw',
+        'name': 'releasedone',
+        'authorization': [{ 'actor': 'finexsidegtw', 'permission': 'gateway' }],
+        'data': '2F02000000000000' }],
+      'transaction_extensions': [1]
+    }
+
+    assert.throws(() => {
+      isTx(tx)
+    }, new Error('ERR_FATAL_INVALID_TX'))
   })
 
   it('isValidTx - outdated', (done) => {

--- a/workers/api.sign.eos.ext.wrk.js
+++ b/workers/api.sign.eos.ext.wrk.js
@@ -188,12 +188,12 @@ class WrkExtEosSignMultisigApi extends WrkApi {
         return data.rows
       },
 
-      lastIrreversibleBlockTimes: async () => {
+      lastIrreversibleBlockTimes: ['pendingLocal', async () => {
         const res = await this._getLastIrreversibleBlockData(localRpc, remoteRpc)
         return res
-      },
+      }],
 
-      stateRemote: ['lastIrreversibleBlockTimes', 'pendingLocal', async () => {
+      stateRemote: ['lastIrreversibleBlockTimes', async () => {
         const data = await remoteRpc.getTableRows({ table: TABLE_STATE, limit: 1 })
 
         if (JSON.stringify(state[local].plocal) !== JSON.stringify(data.rows)) {

--- a/workers/loc.api/sign.eos.ext.js
+++ b/workers/loc.api/sign.eos.ext.js
@@ -6,7 +6,8 @@ const _ = require('lodash')
 
 const {
   sign,
-  addSerializedTx
+  addSerializedTx,
+  isTx
 } = require('../util')
 
 class ExtSignEosMultisig extends Api {
@@ -37,6 +38,10 @@ class ExtSignEosMultisig extends Api {
     if (!ltx) {
       console.log('tx not cached locally, skipping')
       return cb(null, { no_cache: true })
+    }
+
+    if (!isTx(des)) {
+      return cb(null, { outdated: true })
     }
 
     async.waterfall([

--- a/workers/loc.api/sign.eos.ext.js
+++ b/workers/loc.api/sign.eos.ext.js
@@ -34,6 +34,11 @@ class ExtSignEosMultisig extends Api {
     const id = des.actions[0].data
     const ltx = actionCache.get(id)
 
+    if (chain !== data.cHint) {
+      console.error('ERR_BAD_CHINT')
+      throw new Error('ERR_BAD_CHINT')
+    }
+
     // did we already cache it?
     if (!ltx) {
       console.log('tx not cached locally, skipping')

--- a/workers/util.js
+++ b/workers/util.js
@@ -10,6 +10,23 @@ const dns = require('date-fns')
 const _ = require('lodash')
 const async = require('async')
 
+exports.isTx = isTx
+function isTx (des) {
+  if (des.actions.length !== 1 ||
+    des.context_free_actions.length !== 0 ||
+    des.context_free_data ||
+    des.transaction_extensions.length !== 0) {
+    console.error('ERR_FATAL_INVALID_TX', des)
+    throw new Error('ERR_FATAL_INVALID_TX')
+  }
+
+  if (!dns.isFuture(des.expiration)) {
+    return false
+  }
+
+  return true
+}
+
 exports.getTimestamp = getTimestamp
 function getTimestamp (date) {
   if (typeof date !== 'string') {

--- a/workers/util.js
+++ b/workers/util.js
@@ -59,7 +59,7 @@ function createTx (api, contract, action, data, auth) {
 exports.signTx = signTx
 function signTx (data, signer, reqKeys, cb) {
   const { signatureProvider, chainId } = signer
-  const { transfer, tx, exp, signatures, publicKeys, id } = data
+  const { transfer, tx, exp, signatures, publicKeys, id, cHint } = data
 
   transfer.requiredKeys = reqKeys
   transfer.chainId = chainId
@@ -74,7 +74,8 @@ function signTx (data, signer, reqKeys, cb) {
         signatures: signed.signatures.concat(sigs),
         tx: tx,
         exp: exp,
-        id
+        id,
+        cHint
       }
 
       cb(null, res)


### PR DESCRIPTION
- reduces amount of http requests sent in polling by making the pendingTransfer call before getting the block times.

 - sign: tx must be locally cached already

merges the side/main process and shares the cache between main/side to check if tx was already signed locally. 


 - adds additional tx checks